### PR TITLE
A bit of guiding the type system.

### DIFF
--- a/frontend/src/Console.tsx
+++ b/frontend/src/Console.tsx
@@ -84,7 +84,7 @@ class Console extends React.Component<{}, State> {
     }
 }
 
-const itemListStyle = { overflow: 'auto', maxHeight: '200px' }
+const itemListStyle : React.CSSProperties = { overflow: 'auto', maxHeight: '200px' }
 const itemStyle = { fontFamily: 'monospace', border: '1px solid #eee' }
 const logStyle = { ...itemListStyle, background: '#ddffff' }
 const errorStyle = { ...itemListStyle, background: '#ffdddd' }


### PR DESCRIPTION
I'm not sure what changed, but without it, TypeScript would deduct the `overflow` property to be of type string, rather than the string subset type it's going to be assigned to.